### PR TITLE
Handle callback possibly being false

### DIFF
--- a/LibInspect.lua
+++ b/LibInspect.lua
@@ -453,7 +453,9 @@ end
 
 function lib:RunHooks(what, guid)
     for addon,callback in pairs(self.hooks[what]) do
-        callback(guid, self.cache[guid].data, self:GetAge(self.cache[guid].time));
+        if callback then
+            callback(guid, self.cache[guid].data, self:GetAge(self.cache[guid].time));
+        end
     end
 end
 


### PR DESCRIPTION
It is possible that the Blizzard server will respond multiple
times with events signifying you're able to look at a unit's
items, talents, etc. It is also possible that in between
these events the addon can remove the hook responsible for handling
the appropriate event. This leaves a false value being used as a
function in RunHooks.

This patch ensures that the value is not false before we attempt
to use it as a function.