### PR TITLE
Rescan items on GET_ITEM_INFO_RECEIVED

### DIFF
--- a/LibInspect.lua
+++ b/LibInspect.lua
@@ -10,7 +10,6 @@ Methods:
 success = LibInspect:AddHook('MyAddon', type, function(guid, data, age) YourFunction(guid, data, age); end);
 
 maxAge = LibInspect:SetMaxAge(seconds);
-recanQuantity = LibInspect:SetRescan(items);
 
 caninspect, unitfound, refreshing = LibInspect:RequestData(type, target, force);
     or LibInspect:Request_Type_(target, force)
@@ -18,9 +17,9 @@ caninspect, unitfound, refreshing = LibInspect:RequestData(type, target, force);
 
 Callbacks:
     When the data is ready you YourFunction(guid, data, age) will be called
-    
+
     guid = UnitGUID(); use this to tie it to the inspect request
-    
+
     data = false or {
         items = {
             1 = itemLink,
@@ -61,18 +60,24 @@ Callbacks:
         },
         achivements = ...,
     }
-    
+
     age = ##; how old in seconds the data is
 ]]
 
 -- Start the lib
-local lib = LibStub:NewLibrary('LibInspect', 5);
+local lib = LibStub:NewLibrary('LibInspect', 6);
 if not lib then return end
 if not lib.frame then lib.frame = CreateFrame("Frame"); end
 
+local pairs, tonumber, type, time = pairs, tonumber, type, time;
+local NotifyInspect, CanInspect, UnitIsUnit, InCombatLockdown, UnitGUID, GetInventoryItemLink, GetSpecialization = NotifyInspect, CanInspect, UnitIsUnit, InCombatLockdown, UnitGUID, GetInventoryItemLink, GetSpecialization;
+local GetSpecializationInfo, GetInspectSpecialization, GetSpecializationInfoByID, GetSpecializationRoleByID, UnitClass = GetSpecializationInfo, GetInspectSpecialization, GetSpecializationInfoByID, GetSpecializationRoleByID, UnitClass;
+local GetTalentInfo, RequestInspectHonorData, GetInventoryItemID, GetItemInfo = GetTalentInfo, RequestInspectHonorData, GetInventoryItemID, GetItemInfo;
+local NUM_TALENT_COLUMNS, MAX_TALENT_TIERS, INVSLOT_FIRST_EQUIPPED, INVSLOT_LAST_EQUIPPED = NUM_TALENT_COLUMNS, MAX_TALENT_TIERS, INVSLOT_FIRST_EQUIPPED, INVSLOT_LAST_EQUIPPED;
+
+-- GLOBALS: TalentFrame
+
 lib.maxAge = 1800; -- seconds
-lib.rescan = 7; -- What to consider min items
-lib.rescanGUID = {}; -- GUID for 2nd pass scanning
 lib.cache = {};
 lib.hooks = {
     items = {},
@@ -88,7 +93,6 @@ lib.events = {
     achievemnts = "INSPECT_ACHIEVEMENT_READY",
 }
 
--- 
 function lib:AddHook(addon, what, callback)
     if addon and what and callback then
         if type(what) == 'string' then
@@ -97,7 +101,7 @@ function lib:AddHook(addon, what, callback)
                 local h = self:SecureAddHook(addon, 'honor', callback);
                 local t = self:SecureAddHook(addon, 'talents', callback);
                 local a = self:SecureAddHook(addon, 'achievemnts', callback);
-                
+
                 if i and h and t and a then
                     return true;
                 else
@@ -126,12 +130,12 @@ end
 function lib:SecureAddHook(addon, what, callback)
     if self.hooks[what] then
         self.hooks[what][addon] = callback;
-        
+
         -- Register the event
         if self.events[what] then
             self.frame:RegisterEvent(self.events[what]);
         end
-        
+
         return true;
     else
         --- print('LibInspect:SecureAddHook Unkown Type ', addon, what, callback);
@@ -142,7 +146,7 @@ end
 function lib:RemoveHook(addon, what)
     if addon then
         if not what then what = 'all'; end
-        
+
         if what == 'all' then
             self:RemoveHook(addon, 'items');
             self:RemoveHook(addon, 'honor');
@@ -150,7 +154,7 @@ function lib:RemoveHook(addon, what)
             self:RemoveHook(addon, 'achievemnts');
         elseif what == 'items' or what == 'honor' or what == 'talents' or what == 'achievemnts' then
             self.hooks[what][addon] = false;
-            
+
             -- Clean up events if we can
             if self:count(self.hooks[what]) == 0 and self.events[what] then
                 self.frame:UnregisterEvent(self.events[what]);
@@ -169,45 +173,36 @@ function lib:SetMaxAge(maxAge)
     if maxAge < self.maxAge then
         self.maxAge = maxAge;
     end
-    
+
     return self.maxAge;
 end
 
-function lib:SetRescan(items)
-    if tonumber(items) and items >= 0 and items <= 15 then
-        self.rescan = items;
-    end
-    
-    return self.rescan;
-end
-
 function lib:RequestData(what, target, force)
+    self.rescanTarget = nil;
+    self.rescanGUID = nil;
     -- Error out on a few things
     if not target then return false end
     if InCombatLockdown() then return false end
     if not CanInspect(target) then return false end
-    
+
     if not what then what = 'all'; end
-    
+
     -- We can skip some things if target is player
     local skip = false;
     if target == 'player' or UnitIsUnit('player', target) then
         skip = true;
     end
-    
-    -- Manual requests reset the rescan lock
-    self.rescanGUID[target] = 0;
-    
+
     -- Make sure they are in cache
     local guid = self:AddCharacter(target);
-    
+
     if guid then
-        
+
         -- First check for cached
         if self.cache[guid].data == false or self.cache[guid].time == 0 or (time() - self.cache[guid].time) > self.maxAge or force then
-            
+
             self.cache[guid].target = target;
-            
+
             if what == 'all' then
                 self:SafeRequestItems(target, guid, skip);
                 self:SafeRequestHonor(target, guid, skip);
@@ -224,7 +219,7 @@ function lib:RequestData(what, target, force)
                 --- print('LibInspect:RequestData Unkown Type ', what);
                 return false;
             end
-            
+
             return true, true, true;
         else
             if what == 'all' then
@@ -244,7 +239,7 @@ function lib:RequestData(what, target, force)
                 --- print('LibInspect:RequestData Unkown Type ', what);
                 return false;
             end
-            
+
             return true, true, false;
         end
     else
@@ -267,20 +262,20 @@ function lib:SafeRequestItems(target, guid, skip)
         self:InspectReady(guid)
         return
     end
-    
+
     local canInspect = false;
-    
+
     if not self.cache[guid].inspect then
         canInspect = true;
     elseif self.cache[guid].inspect and tonumber(self.cache[guid].inspect) and self:GetAge(self.cache[guid].inspect) > 5 then
         canInspect = true;
     end
-    
+
     if canInspect then
-        
+
         -- Fix an inspect frame bug, may be fixed in 4.3
         -- if InspectFrame then InspectFrame.unit = target; end
-        
+
         --- print('LibInspect:SafeRequestItems running NotifyInspect for', UnitName(target), target);
         self.cache[guid].inspect = time();
         NotifyInspect(target);
@@ -298,65 +293,86 @@ function lib:InspectReady(guid)
     -- Few more error checks
     if not guid then return false end
     if InCombatLockdown() then return false end
-    
+
     --- print('LibInspect:InspectReady', guid, self.cache[guid]);
-    
+
     -- Make sure we have a target and its the same as the cache
     if self.cache[guid] and self.cache[guid].target and UnitGUID(self.cache[guid].target) == guid then
         local target = self.cache[guid].target;
-        
+
         -- Make sure we can still inspect them still
         if CanInspect(target) then
             self.cache[guid].time = time();
-            
+
             if not self.cache[guid].data then
                 self.cache[guid].data = {};
             end
-            
+
             self.cache[guid].inspect = false;
-            self.cache[guid].data['items'] = {};
-            
-            local items, count = self:GetItems(target, guid);
-            local talents = self:GetTalents(target, guid);
-            
-            --- print('LibInspect:InspectReady Done', UnitName(target), guid, self.rescanGUID[target], count);
-            
-            -- Do a 2nd pass if there aren't many items
-            if count <= self.rescan and self.rescanGUID[target] ~= guid then
-                --- print('LibInspect:InspectReady Rescaning', UnitName('target'), count, self.rescan, self.rescanGUID[target], guid);
-                self.rescanGUID[target] = guid;
-                self:SafeRequestItems(target, guid);
-                return false;
+            self.cache[guid].data.talents = self:GetTalents(target, guid);
+            self:RunHooks('talents', guid);
+
+            local items, count, uncached = self:GetItems(target, guid);
+            --- print('LibInspect:InspectReady Done', UnitName(target), count, uncached, target, guid);
+
+            -- Check again on GET_ITEM_INFO_RECEIVED if the client didn't cache all items yet
+            if uncached > 0 then
+                --- print('LibInspect:InspectReady Rescanning', UnitName(target), count, uncached, target, guid);
+                self.rescanTarget = target;
+                self.rescanGUID = guid;
+                self:ItemInfoReceived();
+            else
+                self.cache[guid].data.items = items;
+                self:RunHooks('items', guid);
             end
-            
-            
-            self.cache[guid].data.items = items;
-            self.cache[guid].data.talents = talents;
+        else
+            self:RunHooks('items', guid);
+            self:RunHooks('talents', guid);
         end
-        
-        self:RunHooks('items', guid);
-        self:RunHooks('talents', guid);
+    end
+end
+
+function lib:ItemInfoReceived(itemID, success)
+    --- print('LibInspect:OnItemInfoReceived', self.rescanTarget, self.rescanGUID, itemID, success);
+    if self.rescanTarget and self.rescanGUID then
+        local items, _, uncached = self:GetItems(self.rescanTarget, self.rescanGUID);
+        --- print('LibInspect:OnItemInfoReceived', uncached);
+        if uncached == 0 then
+            self.cache[self.rescanGUID].data.items = items;
+            self:RunHooks('items', self.rescanGUID);
+        end
+    else
+        self.frame:UnregisterEvent("GET_ITEM_INFO_RECEIVED");
     end
 end
 
 function lib:GetItems(target, guid)
     if CanInspect(target) then
         local items = {};
-        local count = 0;
-        
+        local count, uncached = 0, 0;
+
         for i = INVSLOT_FIRST_EQUIPPED, INVSLOT_LAST_EQUIPPED do
             local itemLink = GetInventoryItemLink(target, i);
+            local itemID = GetInventoryItemID(target, i);
             items[i] = itemLink;
             
             if itemLink then 
                  --- print('LibInspect:GetItems', UnitName(target), i, itemLink);
                 count = count + 1; 
+            elseif itemID and not GetItemInfo(itemID) then
+                uncached = uncached + 1;
             end
         end
         
         --- print('LibInspect:GetItems Total', UnitName(target), count);
+
+        if uncached > 0 then
+            self.frame:RegisterEvent("GET_ITEM_INFO_RECEIVED")
+        else
+            self.frame:UnregisterEvent("GET_ITEM_INFO_RECEIVED")
+        end
         
-        return items, count;
+        return items, count, uncached;
     else
         return false;
     end
@@ -365,7 +381,7 @@ end
 function lib:GetTalents(target, guid)
     if CanInspect(target) then
         local specID
-        
+
         if target == 'player' or UnitIsUnit('player', target) then
             if GetSpecialization() then
                 specID = GetSpecializationInfo(GetSpecialization())
@@ -375,49 +391,49 @@ function lib:GetTalents(target, guid)
         else
             specID = GetInspectSpecialization(target)
         end
-        
-		if (specID) then
-			
-			local id, name, description, icon, background = GetSpecializationInfoByID(specID)
-			local role = GetSpecializationRoleByID(specID)
-			
-			local talents = {
-				id = id,
-				name = name,
-				description = description,
-				icon = icon,
-				background = background,
-				role = role,
-				glyphs = {},  -- Removed in 7.03, left for compatability
-				talents = {},
-			};
 
-			-- Talents
-			local classDisplayName, class, classID = UnitClass(target);
-			if TalentFrame then
-				for tier=1, MAX_TALENT_TIERS do
-					local talentRow = TalentFrame["tier"..tier];
-					local rowAvailable = true;
-					
-					for column=1, NUM_TALENT_COLUMNS do
-						local talentID, name, iconTexture, selected, available = GetTalentInfo(tier, column, TalentFrame.talentGroup, TalentFrame.inspect, talentUnit);
-						-- local name, iconTexture, tier, column, selected, available = GetTalentInfo(tier, true, nil, target, self.cache[guid].classID);
-						talents.talents[tier] = {
-							name = name,
-							iconTexture = iconTexture,
-							tier = tier,
-							column = column,
-							selected = selected,
-							available = available,
-						}
-					end
-				end
-			end
+        if (specID) then
 
-			return talents;
-		else
-			return false;
-		end
+            local id, name, description, icon, background = GetSpecializationInfoByID(specID)
+            local role = GetSpecializationRoleByID(specID)
+
+            local talents = {
+                id = id,
+                name = name,
+                description = description,
+                icon = icon,
+                background = background,
+                role = role,
+                glyphs = {},  -- Removed in 7.03, left for compatability
+                talents = {},
+            };
+
+            -- Talents
+            local classDisplayName, class, classID = UnitClass(target);
+            if TalentFrame then
+                for tier=1, MAX_TALENT_TIERS do
+                    local talentRow = TalentFrame["tier"..tier];
+                    local rowAvailable = true;
+
+                    for column=1, NUM_TALENT_COLUMNS do
+                        local talentID, name, iconTexture, selected, available = GetTalentInfo(tier, column, TalentFrame.talentGroup, TalentFrame.inspect, target);
+                        -- local name, iconTexture, tier, column, selected, available = GetTalentInfo(tier, true, nil, target, self.cache[guid].classID);
+                        talents.talents[tier] = {
+                            name = name,
+                            iconTexture = iconTexture,
+                            tier = tier,
+                            column = column,
+                            selected = selected,
+                            available = available,
+                        }
+                    end
+                end
+            end
+
+            return talents;
+        else
+            return false;
+        end
     else
         return false;
     end
@@ -426,7 +442,7 @@ end
 
 function lib:AddCharacter(target)
     local guid = UnitGUID(target);
-    
+
     if guid then
         -- Set up information
         if not self.cache[guid] then
@@ -440,10 +456,10 @@ function lib:AddCharacter(target)
                 classID = classID,
             };
         end
-        
+
         -- Update target cache
         self.cache[guid].target = target;
-        
+
         -- Return guid to save on calls
         return guid;
     else
@@ -469,11 +485,11 @@ end
 
 function lib:count(tbl)
     local i = 0;
-    
+
     for k,v in pairs(tbl) do
         i = i + 1;
     end
-    
+
     return i;
 end
 
@@ -485,6 +501,8 @@ local function OnEvent(self, event, ...)
         lib:InspectHonorUpdate(...);
     elseif event == 'INSPECT_ACHIEVEMENT_READY' then
         lib:InspectAchievementReady(...);
+    elseif event == 'GET_ITEM_INFO_RECEIVED' then
+        lib:ItemInfoReceived(...);
     end
 end
 


### PR DESCRIPTION
I got a lot of incomplete results because of uncached items on the BfA beta, so I added GET_ITEM_INFO_RECEIVED event to handle them. Characters now will be rescanned when GET_ITEM_INFO_RECEIVED fires, so there should be no more incomplete results.

Some notes:

- Saving the IDs of all the uncached items and waiting for all of them to raise GET_ITEM_INFO_RECEIVED was unreliable so I just check all the items again when the event fires. I'm not sure if this could cause issues when TradeSkillMaster requests thousand of items at the same time, someone should propably test this.
- I'm using GetInventoryItemID in lib:GetItems to determine if a character should have an item in a slot when GetInventoryItemLink returns nil. (The additional GetItemInfo call is because of a transmogrify bug - when a druid transmogrifies a polearm to Claws of Ursoc than GetInventoryItemID returns its item ID on the offhand slot, even though there's actually no item - already reported to Blizzard.)